### PR TITLE
fix "ValueError: too many values to unpack" at cv2.findContours

### DIFF
--- a/lib/utils/vis.py
+++ b/lib/utils/vis.py
@@ -104,7 +104,7 @@ def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     img[idx[0], idx[1], :] += alpha * col
 
     if show_border:
-        contours, _ = cv2.findContours(
+        _, contours, _ = cv2.findContours(
             mask.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
         cv2.drawContours(img, contours, -1, _WHITE, border_thick, cv2.LINE_AA)
 


### PR DESCRIPTION
This PR fix the issue vis_one_image_opencv raises ValueError.

>Since OpenCV 3.2, findContours() no longer modifies the source image but returns a modified image as the first of three return parameters.
https://docs.opencv.org/3.3.1/d4/d73/tutorial_py_contours_begin.html

and this line also assumes opencv>=3.2
https://github.com/facebookresearch/Detectron/blob/master/lib/utils/vis.py#L326

so, It may be better to set OpenCV version specification to 3.2 or higher in Installation guide.