### PR TITLE
use opencv instead of numpy to subtract pixel means

### DIFF
--- a/lib/utils/blob.py
+++ b/lib/utils/blob.py
@@ -76,7 +76,8 @@ def prep_im_for_blob(im, pixel_means, target_sizes, max_size):
     the scale factors that were used to compute each returned image.
     """
     im = im.astype(np.float32, copy=False)
-    im -= pixel_means
+    #im -= pixel_means
+    im = cv2.subtract(im, pixel_means.reshape((1,) + im.shape[-1:]))
     im_shape = im.shape
     im_size_min = np.min(im_shape[0:2])
     im_size_max = np.max(im_shape[0:2])


### PR DESCRIPTION
Using numpy to subtract pixel means is slow when image is not small. 
As we already using opencv to do image resizing, I think it' better to also use opencv to do subtraction.
By using opencv, it can reduce total inference time by about 17ms on my 8700K machine for an image with size 1352x900.

The following test code shows the correctness and performance gain.
Some test results:
On 8700K machine:
('numpy timecost', 0.025714427947998046)
('opencv timecost', 0.0030607531070709227)
On some Azure cheap instance:
numpy timecost 0.2105223798751831
opencv timecost 0.03022796869277954

```
import cv2
import numpy as np
import time

# prepare fake data
pixel_means = np.array([[[102.9801, 115.9465, 122.7717]]])
pixel_means_negative = -pixel_means
input_im = np.random.randint(256, size=(900, 1352, 3), dtype='uint8')

# test code, refer to the prep_im_for_blob() function
test_iteration = 1000
im = input_im.astype(np.float32)
t = time.time()
for _ in range(test_iteration):
    im -= pixel_means
    im -= pixel_means_negative
timecost = time.time() - t
assert np.allclose(im, input_im, rtol=0, atol=1e-4)
print("numpy timecost", timecost/test_iteration)

im = input_im.astype(np.float32)
t = time.time()
for _ in range(test_iteration):
    im2 = cv2.subtract(im, pixel_means.reshape((1,) + im.shape[-1:]))
    im2 = cv2.subtract(im, pixel_means_negative.reshape((1,) + im.shape[-1:]))
timecost = time.time() - t
assert np.allclose(im, input_im, rtol=0, atol=1e-4)
print("opencv timecost", timecost/test_iteration)

```