### PR TITLE
infer_simple.py handle train weights

### DIFF
--- a/tools/infer_simple.py
+++ b/tools/infer_simple.py
@@ -94,6 +94,7 @@ def main(args):
     logger = logging.getLogger(__name__)
     merge_cfg_from_file(args.cfg)
     cfg.TEST.WEIGHTS = args.weights
+    cfg.TRAIN.WEIGHTS = args.weights
     cfg.NUM_GPUS = 1
     assert_and_infer_cfg()
     model = infer_engine.initialize_model_from_cfg()


### PR DESCRIPTION
assert_and_infer_cfg() will check both train weights and test weights, so it will download and cache backbone model weights, which is slow and unnecessary for inference. For example, the official demo in GETTING_STARTED.md will run much faster without  cache the train weights.

So it's better that the train and test will share the same weights during inference.