### PR TITLE
Python 3 compatibility

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -11,7 +11,7 @@ This document provides brief tutorials covering Detectron for inference and trai
 To run inference on a directory of image files (`demo/*.jpg` in this example), you can use the `infer_simple.py` tool. In this example, we're using an end-to-end trained Mask R-CNN model with a ResNet-101-FPN backbone from the model zoo:
 
 ```
-python2 tools/infer_simple.py \
+python tools/infer_simple.py \
     --cfg configs/12_2017_baselines/e2e_mask_rcnn_R-101-FPN_2x.yaml \
     --output-dir /tmp/detectron-visualizations \
     --image-ext jpg \
@@ -35,7 +35,7 @@ Detectron should automatically download the model from the URL specified by the 
 This example shows how to run an end-to-end trained Mask R-CNN model from the model zoo using a single GPU for inference. As configured, this will run inference on all images in `coco_2014_minival` (which must be properly installed).
 
 ```
-python2 tools/test_net.py \
+python tools/test_net.py \
     --cfg configs/12_2017_baselines/e2e_mask_rcnn_R-101-FPN_2x.yaml \
     TEST.WEIGHTS https://s3-us-west-2.amazonaws.com/detectron/35861858/12_2017_baselines/e2e_mask_rcnn_R-101-FPN_2x.yaml.02_32_51.SgT4y1cO/output/train/coco_2014_train:coco_2014_valminusminival/generalized_rcnn/model_final.pkl \
     NUM_GPUS 1
@@ -44,7 +44,7 @@ python2 tools/test_net.py \
 Running inference with the same model using `$N` GPUs (e.g., `N=8`).
 
 ```
-python2 tools/test_net.py \
+python tools/test_net.py \
     --cfg configs/12_2017_baselines/e2e_mask_rcnn_R-101-FPN_2x.yaml \
     --multi-gpu-testing \
     TEST.WEIGHTS https://s3-us-west-2.amazonaws.com/detectron/35861858/12_2017_baselines/e2e_mask_rcnn_R-101-FPN_2x.yaml.02_32_51.SgT4y1cO/output/train/coco_2014_train:coco_2014_valminusminival/generalized_rcnn/model_final.pkl \
@@ -61,7 +61,7 @@ This is a tiny tutorial showing how to train a model on COCO. The model will be 
 #### 1. Training with 1 GPU
 
 ```
-python2 tools/train_net.py \
+python tools/train_net.py \
     --cfg configs/getting_started/tutorial_1gpu_e2e_faster_rcnn_R-50-FPN.yaml \
     OUTPUT_DIR /tmp/detectron-output
 ```
@@ -78,7 +78,7 @@ python2 tools/train_net.py \
 We've also provided configs to illustrate training with 2, 4, and 8 GPUs using learning schedules that will be approximately equivalent to the one used with 1 GPU above. The configs are located at: `configs/getting_started/tutorial_{2,4,8}gpu_e2e_faster_rcnn_R-50-FPN.yaml`. For example, launching a training job with 2 GPUs will look like this:
 
 ```
-python2 tools/train_net.py \
+python tools/train_net.py \
     --multi-gpu-testing \
     --cfg configs/getting_started/tutorial_2gpu_e2e_faster_rcnn_R-50-FPN.yaml \
     OUTPUT_DIR /tmp/detectron-output

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ This document covers how to install Detectron, its dependencies (including Caffe
 
 **Requirements:**
 
-- NVIDIA GPU, Linux, Python2
+- NVIDIA GPU, Linux, Python
 - Caffe2, various standard Python packages, and the COCO API; Instructions for installing these dependencies are found below
 
 **Notes:**
@@ -22,11 +22,11 @@ Please ensure that your Caffe2 installation was successful before proceeding by 
 
 ```
 # To check if Caffe2 build was successful
-python2 -c 'from caffe2.python import core' 2>/dev/null && echo "Success" || echo "Failure"
+python -c 'from caffe2.python import core' 2>/dev/null && echo "Success" || echo "Failure"
 
 # To check if Caffe2 GPU build was successful
 # This must print a number > 0 in order to use Detectron
-python2 -c 'from caffe2.python import workspace; print(workspace.NumCudaDevices())'
+python -c 'from caffe2.python import workspace; print(workspace.NumCudaDevices())'
 ```
 
 If the `caffe2` Python package is not found, you likely need to adjust your `PYTHONPATH` environment variable to include its location (`/path/to/caffe2/build`, where `build` is the Caffe2 CMake build directory).
@@ -49,7 +49,7 @@ cd $COCOAPI/PythonAPI
 make install
 # Alternatively, if you do not have permissions or prefer
 # not to install the COCO API into global site-packages
-python2 setup.py install --user
+python setup.py install --user
 ```
 
 Note that instructions like `# COCOAPI=/path/to/install/cocoapi` indicate that you should pick a path where you'd like to have the software cloned and then set an environment variable (`COCOAPI` in this case) accordingly.
@@ -72,7 +72,7 @@ cd $DETECTRON/lib && make
 Check that Detectron tests pass (e.g. for [`SpatialNarrowAsOp test`](tests/test_spatial_narrow_as_op.py)):
 
 ```
-python2 $DETECTRON/tests/test_spatial_narrow_as_op.py
+python $DETECTRON/tests/test_spatial_narrow_as_op.py
 ```
 
 ## That's All You Need for Inference
@@ -101,7 +101,7 @@ cd $DETECTRON/lib && make ops
 Check that the custom operator tests pass:
 
 ```
-python2 $DETECTRON/tests/test_zero_even_op.py
+python $DETECTRON/tests/test_zero_even_op.py
 ```
 
 ## Docker Image
@@ -118,7 +118,7 @@ docker build -t detectron:c2-cuda9-cudnn7 .
 Run the image (e.g. for [`BatchPermutationOp test`](tests/test_batch_permutation_op.py)):
 
 ```
-nvidia-docker run --rm -it detectron:c2-cuda9-cudnn7 python2 tests/test_batch_permutation_op.py
+nvidia-docker run --rm -it detectron:c2-cuda9-cudnn7 python tests/test_batch_permutation_op.py
 ```
 
 ## Troubleshooting
@@ -200,8 +200,8 @@ library and include dir by using:
 ```
 cmake .. \
   # insert your Caffe2 CMake flags here
-  -DPYTHON_LIBRARY=$(python2 -c "from distutils import sysconfig; print(sysconfig.get_python_lib())") \
-  -DPYTHON_INCLUDE_DIR=$(python2 -c "from distutils import sysconfig; print(sysconfig.get_python_inc())")
+  -DPYTHON_LIBRARY=$(python -c "from distutils import sysconfig; print(sysconfig.get_python_lib())") \
+  -DPYTHON_INCLUDE_DIR=$(python -c "from distutils import sysconfig; print(sysconfig.get_python_inc())")
 ```
 
 ### Caffe2 with NNPACK Build

--- a/PYTHON2_TO_PYTHON3_NOTES.md
+++ b/PYTHON2_TO_PYTHON3_NOTES.md
@@ -8,12 +8,18 @@
 
 * fix ``urllib`` compatibility (``response.info().getheader`` breaks)
 
+* the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1,
+  so use ``pickle.load(f, encoding='latin1')``; see also https://github.com/tflearn/tflearn/issues/57
+  However, Python 2 doesn't have an ``encoding`` argument to pickle, so a check is needed
+  (try/except or sys version) for compatibility.
+
 * Be careful when processing values of type ``bytes``, they may be intended to be ascii strings
   (as they were in python 2)... e.g. ``if isinstance(somestr,bytes): somestr.decode('ascii')``,
   which is what ``bytes2string`` does in ``lib/utils/py3compat.py``.
 
-* the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1,
-  so use ``pickle.load(f, encoding='latin1')``
+* Also some types appear in Python 2 as ``unicode``... need to decode them using ``latin1``.
+  2to3 will change ``unicode`` to ``str``, which will leave an error if using ``unicode_str.decode()``,
+  so that has to be checked too.
 
 # Git notes
 

--- a/PYTHON2_TO_PYTHON3_NOTES.md
+++ b/PYTHON2_TO_PYTHON3_NOTES.md
@@ -1,2 +1,14 @@
+
+# Summary of changes
+
 * ``grep -r "python2"`` and replace all ``python2`` to just ``python``
-* TODO: run ``2to3``, there will be bugs
+
+* check ``with open(filename, 'r')`` and ``with open(filename, 'w')``...
+ if they are opening pickle or other binary files, they need to be opened as ``'wb'`` or ``'rb'``.
+
+I am intentionally not running ``2to3``, because it makes too many changes, and the git changelog would be overwhelming.
+
+# How to use under Python 3
+
+* Finally, to convert to python 3, run this: ``2to3 -wn .``
+

--- a/PYTHON2_TO_PYTHON3_NOTES.md
+++ b/PYTHON2_TO_PYTHON3_NOTES.md
@@ -1,0 +1,2 @@
+* ``grep -r "python2"`` and replace all ``python2`` to just ``python``
+* TODO: run ``2to3``, there will be bugs

--- a/PYTHON2_TO_PYTHON3_NOTES.md
+++ b/PYTHON2_TO_PYTHON3_NOTES.md
@@ -6,9 +6,22 @@
 * check ``with open(filename, 'r')`` and ``with open(filename, 'w')``...
  if they are opening pickle or other binary files, they need to be opened as ``'wb'`` or ``'rb'``.
 
-I am intentionally not running ``2to3``, because it makes too many changes, and the git changelog would be overwhelming.
+* fix ``urllib`` compatibility (``response.info().getheader`` breaks)
 
-# How to use under Python 3
+* Be careful when processing values of type ``bytes``, they may be intended to be ascii strings
+  (as they were in python 2)... e.g. ``if isinstance(somestr,bytes): somestr.decode('ascii')``,
+  which is what ``bytes2string`` does in ``lib/utils/py3compat.py``.
 
-* Finally, to convert to python 3, run this: ``2to3 -wn .``
+* the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1,
+  so use ``pickle.load(f, encoding='latin1')``
 
+# Git notes
+
+``2to3`` makes too many changes, and the git changelog would be overwhelming.
+
+Instead this repo remains Python2 code, and fixes issues that ``2to3`` won't fix by itself.
+
+# How to use with Python 3
+
+* To convert to python 3, run this from the root directory: ``2to3 -wn .``
+* Let ``#!/usr/bin/env python`` map to python 3 (I'd suggest using a python virtual environment)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,12 +1,12 @@
 # Don't use the --user flag for setup.py develop mode with virtualenv.
-DEV_USER_FLAG=$(shell python2 -c "import sys; print('' if hasattr(sys, 'real_prefix') else '--user')")
+DEV_USER_FLAG=$(shell python -c "import sys; print('' if hasattr(sys, 'real_prefix') else '--user')")
 
 .PHONY: default
 default: dev
 
 .PHONY: install
 install:
-	python2 setup.py install
+	python setup.py install
 
 .PHONY: ops
 ops:
@@ -14,9 +14,9 @@ ops:
 
 .PHONY: dev
 dev:
-	python2 setup.py develop $(DEV_USER_FLAG)
+	python setup.py develop $(DEV_USER_FLAG)
 
 .PHONY: clean
 clean:
-	python2 setup.py develop --uninstall $(DEV_USER_FLAG)
+	python setup.py develop --uninstall $(DEV_USER_FLAG)
 	rm -rf build

--- a/lib/core/config.py
+++ b/lib/core/config.py
@@ -1160,7 +1160,7 @@ def _decode_cfg_value(v):
     # All remaining processing is only applied to strings
     if isinstance(v, bytes): # assume bytes are encoded ascii strings (thats how they are in python 2)
         v = v.decode('ascii')
-    if not isinstance(v, str):
+    if not isinstance(v, str) and not isinstance(v, unicode):
         return v
     # Try to interpret `v` as a:
     #   string, number, tuple, list, dict, boolean, or None
@@ -1191,6 +1191,9 @@ def _check_and_coerce_cfg_value_type(value_a, value_b, key, full_key):
     """
     if isinstance(value_a, bytes) and isinstance(value_b, bytes):
         return value_a.decode('ascii') # assume bytes are encoded ascii strings (thats how they are in python 2)
+    if isinstance(value_a, unicode):
+        assert isinstance(value_b, str) or isinstance(value_b, unicode), str(type(value_b))
+        return value_a.decode('latin1')  # https://github.com/tflearn/tflearn/issues/57
 
     # The types must match (with some exceptions)
     type_b = type(value_b)

--- a/lib/core/config.py
+++ b/lib/core/config.py
@@ -48,6 +48,7 @@ from utils.collections import AttrDict
 import copy
 import logging
 import numpy as np
+import sys
 import os
 import os.path as osp
 import yaml
@@ -1191,7 +1192,7 @@ def _check_and_coerce_cfg_value_type(value_a, value_b, key, full_key):
     """
     if isinstance(value_a, bytes) and isinstance(value_b, bytes):
         return value_a.decode('ascii') # assume bytes are encoded ascii strings (thats how they are in python 2)
-    if isinstance(value_a, unicode):
+    if sys.version_info.major == 2 and isinstance(value_a, unicode):
         assert isinstance(value_b, str) or isinstance(value_b, unicode), str(type(value_b))
         return value_a.decode('latin1')  # https://github.com/tflearn/tflearn/issues/57
 

--- a/lib/datasets/cityscapes/tools/convert_coco_model_to_cityscapes.py
+++ b/lib/datasets/cityscapes/tools/convert_coco_model_to_cityscapes.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
         'Weights file does not exist'
     weights = load_and_convert_coco_model(args)
 
-    with open(args.out_file_name, 'w') as f:
+    with open(args.out_file_name, 'wb') as f:
         pickle.dump(weights, f, protocol=pickle.HIGHEST_PROTOCOL)
     print('Wrote blobs to {}:'.format(args.out_file_name))
     print(sorted(weights['blobs'].keys()))

--- a/lib/datasets/json_dataset.py
+++ b/lib/datasets/json_dataset.py
@@ -255,7 +255,7 @@ class JsonDataset(object):
     ):
         """Add proposals from a proposals file to an roidb."""
         logger.info('Loading proposals from: {}'.format(proposal_file))
-        with open(proposal_file, 'r') as f:
+        with open(proposal_file, 'rb') as f:
             proposals = pickle.load(f)
         id_field = 'indexes' if 'indexes' in proposals else 'ids'  # compat fix
         _sort_proposals(proposals, id_field)

--- a/lib/datasets/roidb.py
+++ b/lib/datasets/roidb.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from past.builtins import basestring
+#from past.builtins import basestring
 import logging
 import numpy as np
 

--- a/lib/datasets/voc_eval.py
+++ b/lib/datasets/voc_eval.py
@@ -136,11 +136,11 @@ def voc_eval(detpath,
                         i + 1, len(imagenames)))
         # save
         logger.info('Saving cached annotations to {:s}'.format(cachefile))
-        with open(cachefile, 'w') as f:
+        with open(cachefile, 'wb') as f:
             cPickle.dump(recs, f)
     else:
         # load
-        with open(cachefile, 'r') as f:
+        with open(cachefile, 'rb') as f:
             recs = cPickle.load(f)
 
     # extract gt objects for this class

--- a/lib/modeling/model_builder.py
+++ b/lib/modeling/model_builder.py
@@ -55,6 +55,7 @@ import modeling.rfcn_heads as rfcn_heads
 import modeling.rpn_heads as rpn_heads
 import roi_data.minibatch
 import utils.c2 as c2_utils
+from utils.py3compat import bytes2string
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +130,7 @@ def get_func(func_name):
     function in this module or the path to a function relative to the base
     'modeling' module.
     """
+    func_name = bytes2string(func_name)
     if func_name == '':
         return None
     new_func_name = modeling.name_compat.get_new_name(func_name)

--- a/lib/utils/io.py
+++ b/lib/utils/io.py
@@ -27,6 +27,7 @@ import os
 import re
 import sys
 import urllib2
+from utils.py3compat import bytes2string
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,9 @@ def cache_url(url_or_file, cache_dir):
     path to the cached file. If the argument is not a URL, simply return it as
     is.
     """
+    url_or_file = bytes2string(url_or_file)
+    cache_dir   = bytes2string(cache_dir)
+
     is_url = re.match(r'^(?:http)s?://', url_or_file, re.IGNORECASE) is not None
 
     if not is_url:
@@ -112,8 +116,11 @@ def download_url(
     https://stackoverflow.com/questions/2028517/python-urllib2-progress-hook
     """
     response = urllib2.urlopen(url)
-    total_size = response.info().getheader('Content-Length').strip()
-    total_size = int(total_size)
+    try:
+        total_size = response.info().getheader('Content-Length')  # python 2
+    except AttributeError:
+        total_size = response.info()['Content-Length']  # python 3
+    total_size = int(total_size.strip())
     bytes_so_far = 0
 
     with open(dst_file_path, 'wb') as f:

--- a/lib/utils/io.py
+++ b/lib/utils/io.py
@@ -132,7 +132,7 @@ def download_url(
 def _get_file_md5sum(file_name):
     """Compute the md5 hash of a file."""
     hash_obj = hashlib.md5()
-    with open(file_name, 'r') as f:
+    with open(file_name, 'rb') as f:
         hash_obj.update(f.read())
     return hash_obj.hexdigest()
 

--- a/lib/utils/net.py
+++ b/lib/utils/net.py
@@ -57,7 +57,7 @@ def initialize_gpu_from_weights_file(model, weights_file, gpu_id=0):
     logger.info('Loading weights from: {}'.format(weights_file))
     ws_blobs = workspace.Blobs()
     with open(weights_file, 'rb') as f:
-        src_blobs = pickle.load(f)
+        src_blobs = pickle.load(f, encoding='latin1')  # the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1
     if 'cfg' in src_blobs:
         saved_cfg = yaml.load(src_blobs['cfg'])
         configure_bbox_reg_weights(model, saved_cfg)

--- a/lib/utils/net.py
+++ b/lib/utils/net.py
@@ -56,7 +56,7 @@ def initialize_gpu_from_weights_file(model, weights_file, gpu_id=0):
     """
     logger.info('Loading weights from: {}'.format(weights_file))
     ws_blobs = workspace.Blobs()
-    with open(weights_file, 'r') as f:
+    with open(weights_file, 'rb') as f:
         src_blobs = pickle.load(f)
     if 'cfg' in src_blobs:
         saved_cfg = yaml.load(src_blobs['cfg'])

--- a/lib/utils/net.py
+++ b/lib/utils/net.py
@@ -57,7 +57,10 @@ def initialize_gpu_from_weights_file(model, weights_file, gpu_id=0):
     logger.info('Loading weights from: {}'.format(weights_file))
     ws_blobs = workspace.Blobs()
     with open(weights_file, 'rb') as f:
-        src_blobs = pickle.load(f, encoding='latin1')  # the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1
+        try:
+            src_blobs = pickle.load(f, encoding='latin1')  # the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1; see also https://github.com/tflearn/tflearn/issues/57
+        except TypeError:
+            src_blobs = pickle.load(f)  # Python 2 has no "encoding" argument for pickle
     if 'cfg' in src_blobs:
         saved_cfg = yaml.load(src_blobs['cfg'])
         configure_bbox_reg_weights(model, saved_cfg)

--- a/lib/utils/py3compat.py
+++ b/lib/utils/py3compat.py
@@ -2,5 +2,7 @@
 def bytes2string(x):
     if isinstance(x,bytes):
         return x.decode('ascii')
+    if isinstance(x,unicode):
+        return x.decode('latin1')  # the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1; see also https://github.com/tflearn/tflearn/issues/57
     assert isinstance(x,str), str(type(x))
     return x

--- a/lib/utils/py3compat.py
+++ b/lib/utils/py3compat.py
@@ -1,0 +1,6 @@
+
+def bytes2string(x):
+    if isinstance(x,bytes):
+        return x.decode('ascii')
+    assert isinstance(x,str), str(type(x))
+    return x

--- a/lib/utils/py3compat.py
+++ b/lib/utils/py3compat.py
@@ -1,8 +1,9 @@
+import sys
 
 def bytes2string(x):
     if isinstance(x,bytes):
         return x.decode('ascii')
-    if isinstance(x,unicode):
+    if sys.version_info.major == 2 and isinstance(x,unicode): # 2to3 turns "unicode" into "str" but we don't want to decode "str" in python 3
         return x.decode('latin1')  # the pickles from the Model Zoo (as of January 2018) seem to be encoded with latin1; see also https://github.com/tflearn/tflearn/issues/57
     assert isinstance(x,str), str(type(x))
     return x

--- a/lib/utils/subprocess.py
+++ b/lib/utils/subprocess.py
@@ -95,7 +95,7 @@ def process_in_parallel(tag, total_range_size, binary, output_dir):
         range_file = os.path.join(
             output_dir, '%s_range_%s_%s.pkl' % (tag, start, end)
         )
-        range_data = pickle.load(open(range_file))
+        range_data = pickle.load(open(range_file, 'rb'))
         outputs.append(range_data)
     return outputs
 

--- a/lib/utils/training_stats.py
+++ b/lib/utils/training_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -83,7 +83,7 @@ class TestCfg(unittest.TestCase):
             core.config.merge_cfg_from_cfg(cfg2)
 
     def test_merge_cfg_from_file(self):
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(mode='w') as f:
             yaml.dump(cfg, f)
             s = cfg.MODEL.TYPE
             cfg.MODEL.TYPE = 'dummy'
@@ -123,7 +123,7 @@ class TestCfg(unittest.TestCase):
     def test_deprecated_key_from_file(self):
         # You should see logger messages like:
         #   "Deprecated config key (ignoring): MODEL.DILATION"
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(mode='w') as f:
             cfg2 = copy.deepcopy(cfg)
             cfg2.MODEL.DILATION = 2
             yaml.dump(cfg2, f)
@@ -147,7 +147,7 @@ class TestCfg(unittest.TestCase):
         # You should see logger messages like:
         #  "Key EXAMPLE.RENAMED.KEY was renamed to EXAMPLE.KEY;
         #  please update your config"
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(mode='w') as f:
             cfg2 = copy.deepcopy(cfg)
             cfg2.EXAMPLE = AttrDict()
             cfg2.EXAMPLE.RENAMED = AttrDict()

--- a/tools/convert_pkl_to_pb.py
+++ b/tools/convert_pkl_to_pb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/convert_selective_search.py
+++ b/tools/convert_selective_search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/generate_testdev_from_test.py
+++ b/tools/generate_testdev_from_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/infer.py
+++ b/tools/infer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/infer_simple.py
+++ b/tools/infer_simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/pickle_caffe_blobs.py
+++ b/tools/pickle_caffe_blobs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/pickle_caffe_blobs.py
+++ b/tools/pickle_caffe_blobs.py
@@ -93,7 +93,7 @@ def pickle_weights(out_file_name, weights):
         normalize_resnet_name(blob.name): utils.Caffe2TensorToNumpyArray(blob)
         for blob in weights.protos
     }
-    with open(out_file_name, 'w') as f:
+    with open(out_file_name, 'wb') as f:
         pickle.dump(blobs, f, protocol=pickle.HIGHEST_PROTOCOL)
     print('Wrote blobs:')
     print(sorted(blobs.keys()))

--- a/tools/reval.py
+++ b/tools/reval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #

--- a/tools/visualize_results.py
+++ b/tools/visualize_results.py
@@ -84,7 +84,7 @@ def vis(dataset, detections_pkl, thresh, output_dir, limit=0):
     ds = JsonDataset(dataset)
     roidb = ds.get_roidb()
 
-    with open(detections_pkl, 'r') as f:
+    with open(detections_pkl, 'rb') as f:
         dets = pickle.load(f)
 
     all_boxes = dets['all_boxes']

--- a/tools/visualize_results.py
+++ b/tools/visualize_results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2017-present, Facebook, Inc.
 #


### PR DESCRIPTION
This leaves the code as Python 2, but sets up the ability to use ``2to3`` for porting to Python 3 by fixing issues that ``2to3`` can't fix by itself. The messiest parts are in ``lib/core/config.py`` and the differences between data types ``bytes``, ``str``, and ``unicode``. Notes on the porting process are recorded here: [PYTHON2_TO_PYTHON3_NOTES.md](https://github.com/jasonbunk/Detectron/blob/master/PYTHON2_TO_PYTHON3_NOTES.md). Tests in ``tests/`` should pass for both Python 2.7 and 3.5, as well as ``tools/infer_simple.py``.