### PR TITLE
Look for lib into virtual/conda env

### DIFF
--- a/lib/utils/env.py
+++ b/lib/utils/env.py
@@ -68,9 +68,15 @@ def get_detectron_ops_lib():
     c2_dir = get_caffe2_dir()
     detectron_ops_lib = os.path.join(
         c2_dir, 'lib/libcaffe2_detectron_ops_gpu.so')
-    assert os.path.exists(detectron_ops_lib), \
-        ('Detectron ops lib not found at \'{}\'; make sure that your Caffe2 '
-         'version includes Detectron module').format(detectron_ops_lib)
+
+    # If not found look into prefix: maybe it installed in a virtual/conda env
+    if not os.path.exists(detectron_ops_lib):
+        prefix_dir = sys.prefix
+        detectron_ops_lib_env = os.path.join(prefix_dir, 'lib', 'libcaffe2_detectron_ops_gpu.so')
+        assert os.path.exists(detectron_ops_lib_env), \
+            ('Detectron ops lib not found at \'{}\'; make sure that your Caffe2 '
+             'version includes Detectron module').format([detectron_ops_lib, detectron_ops_lib_env])
+        return detectron_ops_lib_env
     return detectron_ops_lib
 
 


### PR DESCRIPTION
Small change that makes detectron work with the install instruction of [caffe2 for conda](https://caffe2.ai/docs/getting-started.html?platform=mac&configuration=compile).
Using the compile instructions since detectron needs GPU.

The conda package will place the library into `$PREFIX/lib/libcaffe2_detectron_ops_gpu.so` so detectron has to look at it there instead of only `lib/python2.7/site-packages/lib/libcaffe2_detectron_ops_gpu.so`.

The change only adds a new location to look for so, nothing should break.