### PR TITLE
Fix prep_im_for_blob

### DIFF
--- a/lib/utils/blob.py
+++ b/lib/utils/blob.py
@@ -88,9 +88,9 @@ def prep_im_for_blob(im, pixel_means, target_sizes, max_size):
         # Prevent the biggest axis from being more than max_size
         if np.round(im_scale * im_size_max) > max_size:
             im_scale = float(max_size) / float(im_size_max)
-        im = cv2.resize(im, None, None, fx=im_scale, fy=im_scale,
+        im_prime = cv2.resize(im, None, None, fx=im_scale, fy=im_scale,
                         interpolation=cv2.INTER_LINEAR)
-        ims.append(im)
+        ims.append(im_prime)
         im_scales.append(im_scale)
     return ims, im_scales
 


### PR DESCRIPTION
Bug: im is replaced by cv2.resize(im) and so the target_sizes are not achieved

(This may brake stuff trained with this bug)