### PR TITLE
Allow the user to specify custom datasets in mscoco format

### DIFF
--- a/lib/core/config.py
+++ b/lib/core/config.py
@@ -1043,14 +1043,15 @@ def get_output_dir(datasets, training=True):
     """Get the output directory determined by the current global config."""
     assert isinstance(datasets, (tuple, list, basestring)), \
         'datasets argument must be of type tuple, list or string'
-    is_string = isinstance(datasets, basestring)
-    dataset_name = datasets if is_string else ':'.join(datasets)
+    from os.path import basename
+    if isinstance(datasets, basestring):
+        datasets = [datasets]
+    # If datasets are specified as paths to a file, use the filename without
+    # extensions as the database name in the output directory.
+    dataset_name = ':'.join(basename(p).split('.')[0] for p in datasets)
     tag = 'train' if training else 'test'
     # <output-dir>/<train|test>/<dataset-name>/<model-type>/
-    from os.path import basename
-    from os.path import splitext
-    _name = splitext(basename(dataset_name))[0]
-    outdir = osp.join(__C.OUTPUT_DIR, tag, _name, __C.MODEL.TYPE)
+    outdir = osp.join(__C.OUTPUT_DIR, tag, dataset_name, __C.MODEL.TYPE)
     if not osp.exists(outdir):
         os.makedirs(outdir)
     return outdir

--- a/lib/core/config.py
+++ b/lib/core/config.py
@@ -20,7 +20,6 @@
 # Licensed under The MIT License [see LICENSE for details]
 # Written by Ross Girshick
 # --------------------------------------------------------
-
 """Detectron config system.
 
 This file specifies default config options for Detectron. You should not
@@ -77,6 +76,10 @@ __C.TRAIN.WEIGHTS = b''
 # Available dataset list: datasets.dataset_catalog.DATASETS.keys()
 # If multiple datasets are listed, the model is trained on their union
 __C.TRAIN.DATASETS = ()
+
+# Image directory to use if datasets are specified as file paths to existing
+# files in the mscoco format.
+__C.TRAIN.IM_DIR = ''
 
 # Scales to use during training
 # Each scale is the pixel size of an image's shortest side
@@ -212,6 +215,10 @@ __C.TEST.WEIGHTS = b''
 # Available dataset list: datasets.dataset_catalog.DATASETS.keys()
 # If multiple datasets are listed, testing is performed on each one sequentially
 __C.TEST.DATASETS = ()
+
+# Image directory to use if datasets are specified as file paths to existing
+# files in the mscoco format.
+__C.TEST.IM_DIR = ''
 
 # Scales to use during testing
 # Each scale is the pixel size of an image's shortest side
@@ -1040,7 +1047,10 @@ def get_output_dir(datasets, training=True):
     dataset_name = datasets if is_string else ':'.join(datasets)
     tag = 'train' if training else 'test'
     # <output-dir>/<train|test>/<dataset-name>/<model-type>/
-    outdir = osp.join(__C.OUTPUT_DIR, tag, dataset_name, __C.MODEL.TYPE)
+    from os.path import basename
+    from os.path import splitext
+    _name = splitext(basename(dataset_name))[0]
+    outdir = osp.join(__C.OUTPUT_DIR, tag, _name, __C.MODEL.TYPE)
     if not osp.exists(outdir):
         os.makedirs(outdir)
     return outdir

--- a/lib/datasets/json_dataset.py
+++ b/lib/datasets/json_dataset.py
@@ -61,12 +61,17 @@ class JsonDataset(object):
         assert os.path.exists(DATASETS[name][ANN_FN]), \
             'Annotation file \'{}\' not found'.format(DATASETS[name][ANN_FN])
         logger.debug('Creating: {}'.format(name))
-        self.name = name
+
         self.image_directory = DATASETS[name][IM_DIR]
         self.image_prefix = (
             '' if IM_PREFIX not in DATASETS[name] else DATASETS[name][IM_PREFIX]
         )
         self.COCO = COCO(DATASETS[name][ANN_FN])
+
+        # hack: name might be a path, so only take the filename
+        from os.path import basename
+        self.name = basename(name).split('.')[0]
+
         self.debug_timer = Timer()
         # Set up dataset classes
         category_ids = self.COCO.getCatIds()


### PR DESCRIPTION
Currently, Detectron can only train on datasets specified in its `dataset_catalog`. There is no way to add to this catalog without modifying source code. This is a serious problem.

This PR implements an ugly hack that allows users to specify their own mscoco-style datasets in the yaml config file.

While its not the prettiest code in the world, it is a stop-gap measure that allows for something that should really be a very basic feature. Hopefully someone more familiar with the Detectron codebase can come up with a better more permanent solution, but perhaps this patch will be useful to someone else in the meantime. 

