### PR TITLE
Fix a typo of symlinks in lib/datasets/data/README.md

### DIFF
--- a/lib/datasets/data/README.md
+++ b/lib/datasets/data/README.md
@@ -61,7 +61,7 @@ Create symlinks for `VOC<year>`:
 ```
 mkdir -p $DETECTRON/lib/datasets/data/VOC<year>
 ln -s /path/to/VOC<year>/JPEGImages $DETECTRON/lib/datasets/data/VOC<year>/JPEGImages
-ln -s /path/to/VOC<year>/json/annotations $DETECTRON/lib/datasets/data/VOC<year>annotations
+ln -s /path/to/VOC<year>/json/annotations $DETECTRON/lib/datasets/data/VOC<year>/annotations
 ln -s /path/to/VOC<year>/devkit $DETECTRON/lib/datasets/VOC<year>/VOCdevkit<year>
 ```
 


### PR DESCRIPTION
Missing a '/' when creating symlinks for PASCAL VOC in lib/datasets/data/README.md