### PR TITLE
Split Pascal Voc dataset in lib/datasets/dataset_catalog.py

### DIFF
--- a/detectron/datasets/data/README.md
+++ b/detectron/datasets/data/README.md
@@ -51,7 +51,8 @@ VOC<year>
 |  |_ ...
 |  |_ <im-N-name>.jpg
 |_ annotations
-|  |_ voc_<year>_trainval.json
+|  |_ voc_<year>_train.json
+|  |_ voc_<year>_val.json
 |  |_ ...
 |_ VOCdevkit<year>
 ```

--- a/detectron/datasets/dataset_catalog.py
+++ b/detectron/datasets/dataset_catalog.py
@@ -162,11 +162,19 @@ _DATASETS = {
         _ANN_FN:
             _DATA_DIR + '/coco/annotations/image_info_test-dev2015.json'
     },
-    'voc_2007_trainval': {
+    'voc_2007_train': {
         _IM_DIR:
             _DATA_DIR + '/VOC2007/JPEGImages',
         _ANN_FN:
-            _DATA_DIR + '/VOC2007/annotations/voc_2007_trainval.json',
+            _DATA_DIR + '/VOC2007/annotations/voc_2007_train.json',
+        _DEVKIT_DIR:
+            _DATA_DIR + '/VOC2007/VOCdevkit2007'
+    },
+    'voc_2007_val': {
+        _IM_DIR:
+            _DATA_DIR + '/VOC2007/JPEGImages',
+        _ANN_FN:
+            _DATA_DIR + '/VOC2007/annotations/voc_2007_val.json',
         _DEVKIT_DIR:
             _DATA_DIR + '/VOC2007/VOCdevkit2007'
     },
@@ -178,11 +186,19 @@ _DATASETS = {
         _DEVKIT_DIR:
             _DATA_DIR + '/VOC2007/VOCdevkit2007'
     },
-    'voc_2012_trainval': {
+    'voc_2012_train': {
         _IM_DIR:
             _DATA_DIR + '/VOC2012/JPEGImages',
         _ANN_FN:
-            _DATA_DIR + '/VOC2012/annotations/voc_2012_trainval.json',
+            _DATA_DIR + '/VOC2012/annotations/voc_2012_train.json',
+        _DEVKIT_DIR:
+            _DATA_DIR + '/VOC2012/VOCdevkit2012'
+    },
+    'voc_2012_val': {
+        _IM_DIR:
+            _DATA_DIR + '/VOC2012/JPEGImages',
+        _ANN_FN:
+            _DATA_DIR + '/VOC2012/annotations/voc_2012_val.json',
         _DEVKIT_DIR:
             _DATA_DIR + '/VOC2012/VOCdevkit2012'
     }


### PR DESCRIPTION
I found that the json annotations for Pascal VOC downloaded from the [URL](https://storage.googleapis.com/coco-dataset/external/PASCAL_VOC.zip) in [detectron/datasets/data/README.md](https://github.com/facebookresearch/Detectron/blob/master/detectron/datasets/data/README.md#pascal-voc-annotations-in-coco-format) are split into three sets: 'train', 'val' and 'test'.
Therefor, it's unable to use 'trainval' set directly.
For example, the code can't found the 'voc_2007_trainval.json' file when using the following configure:
```python
TRAIN:
  DATASETS: ('voc_2007_trainval',)
TEST:
  DATASETS: ('voc_2007_test',)
```

I suggest to split Pascal VOC dataset in [detectron/datasets/dataset_catalog.py](https://github.com/facebookresearch/Detectron/blob/master/detectron/datasets/dataset_catalog.py)

So we can train detectors using 'train' and 'val' set together:
```python
TRAIN:
  DATASETS: ('voc_2007_train', 'voc_2007_val')
TEST:
  DATASETS: ('voc_2007_test',)
```

Although it's possible to merge the json annotations manually, the above modifications make it more flexible to choice the data set. 