### PR TITLE
Miss a 'None' in return values of create_model() in tools/train_net.py

### DIFF
--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -182,7 +182,7 @@ def create_model():
         final_path = os.path.join(output_dir, 'model_final.pkl')
         if os.path.exists(final_path):
             logger.info('model_final.pkl exists; no need to train!')
-            return None, None, {'final': final_path}, output_dir
+            return None, None, None, {'final': final_path}, output_dir
 
         # Find the most recent checkpoint (highest iteration number)
         files = os.listdir(output_dir)


### PR DESCRIPTION
When 'model_final.pkl' exists, the following error occurs:
```shell
INFO train_net.py: 184: model_final.pkl exists; no need to train!
Traceback (most recent call last):
  File "tools/train_net.py", line 280, in <module>
    main()
  File "tools/train_net.py", line 119, in main
    checkpoints = train_model()
  File "tools/train_net.py", line 128, in train_model
    model, weights_file, start_iter, checkpoints, output_dir = create_model()
ValueError: need more than 4 values to unpack
```
It misses a return value.