### PR TITLE
Shuffle roidb inds should refer to cfg.TRAIN.IMS_PER_BATCH

### DIFF
--- a/lib/roi_data/loader.py
+++ b/lib/roi_data/loader.py
@@ -149,7 +149,7 @@ class RoIDataLoader(object):
                     np.random.permutation(vert_inds)
                 )
             )
-            inds = np.reshape(inds, (-1, 2))
+            inds = np.reshape(inds, (-1, cfg.TRAIN.IMS_PER_BATCH))
             row_perm = np.random.permutation(np.arange(inds.shape[0]))
             inds = np.reshape(inds[row_perm, :], (-1, ))
             self._perm = inds


### PR DESCRIPTION
Originally, it's hard-coded to 2, which is the default value `cfg.TRAIN.IMS_PER_BATCH`, on reshaping the indices.