### PR TITLE
Do not download TRAIN.WEIGHTS in infer_simple.py & infer.py

### DIFF
--- a/tools/infer.py
+++ b/tools/infer.py
@@ -105,7 +105,7 @@ def get_rpn_box_proposals(im, args):
     cfg.MODEL.RPN_ONLY = True
     cfg.TEST.RPN_PRE_NMS_TOP_N = 10000
     cfg.TEST.RPN_POST_NMS_TOP_N = 2000
-    assert_and_infer_cfg()
+    assert_and_infer_cfg(cache_urls=False)
 
     model = model_engine.initialize_model_from_cfg(args.rpn_pkl)
     with c2_utils.NamedCudaScope(0):
@@ -137,7 +137,7 @@ def main(args):
         else:
             weights_file = cfg.TEST.WEIGHTS
         cfg.NUM_GPUS = 1
-        assert_and_infer_cfg()
+        assert_and_infer_cfg(cache_urls=False)
         model = model_engine.initialize_model_from_cfg(weights_file)
         with c2_utils.NamedCudaScope(0):
             cls_boxes_, cls_segms_, cls_keyps_ = \

--- a/tools/infer_simple.py
+++ b/tools/infer_simple.py
@@ -96,7 +96,7 @@ def main(args):
     merge_cfg_from_file(args.cfg)
     cfg.NUM_GPUS = 1
     args.weights = cache_url(args.weights, cfg.DOWNLOAD_CACHE)
-    assert_and_infer_cfg()
+    assert_and_infer_cfg(cache_urls=False)
     model = infer_engine.initialize_model_from_cfg(args.weights)
     dummy_coco_dataset = dummy_datasets.get_coco_dataset()
 


### PR DESCRIPTION
Before this change <code>assert_and_infer_cfg</code> would override the weights passed by the user with CFG ones.

It is normal to change it as the user is required to pass weights, otherwise there will be this error :
<code>AssertionError: <class 'NoneType'></code>. (verified only in infer_simple.py)

Sort of follow-up of eddb130.