### PR TITLE
Fix errors in vis.py

### DIFF
--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -113,6 +113,7 @@ def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
 
 def vis_class(img, pos, class_str, font_scale=0.35):
     """Visualizes the class."""
+    
     img = img.astype(np.uint8)
     x0, y0 = int(pos[0]), int(pos[1])
     # Compute text size.
@@ -131,6 +132,7 @@ def vis_class(img, pos, class_str, font_scale=0.35):
 
 def vis_bbox(img, bbox, thick=1):
     """Visualizes a bounding box."""
+    
     img = img.astype(np.uint8)
     (x0, y0, w, h) = bbox
     x1, y1 = int(x0 + w), int(y0 + h)

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -96,7 +96,6 @@ def get_class_string(class_index, score, dataset):
 
 def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     """Visualizes a single binary mask."""
-
     img = img.astype(np.float32)
     idx = np.nonzero(mask)
 
@@ -113,7 +112,6 @@ def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
 
 def vis_class(img, pos, class_str, font_scale=0.35):
     """Visualizes the class."""
-    
     img = img.astype(np.uint8)
     x0, y0 = int(pos[0]), int(pos[1])
     # Compute text size.
@@ -132,7 +130,6 @@ def vis_class(img, pos, class_str, font_scale=0.35):
 
 def vis_bbox(img, bbox, thick=1):
     """Visualizes a bounding box."""
-    
     img = img.astype(np.uint8)
     (x0, y0, w, h) = bbox
     x1, y1 = int(x0 + w), int(y0 + h)
@@ -206,7 +203,6 @@ def vis_one_image_opencv(
         im, boxes, segms=None, keypoints=None, thresh=0.9, kp_thresh=2,
         show_box=False, dataset=None, show_class=False):
     """Constructs a numpy array with the detections visualized."""
-
     if isinstance(boxes, list):
         boxes, segms, keypoints, classes = convert_from_cls_format(
             boxes, segms, keypoints)

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -96,7 +96,7 @@ def get_class_string(class_index, score, dataset):
 
 def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     """Visualizes a single binary mask."""
-    
+
     img = img.astype(np.float32)
     idx = np.nonzero(mask)
 
@@ -204,7 +204,7 @@ def vis_one_image_opencv(
         im, boxes, segms=None, keypoints=None, thresh=0.9, kp_thresh=2,
         show_box=False, dataset=None, show_class=False):
     """Constructs a numpy array with the detections visualized."""
-    
+
     if isinstance(boxes, list):
         boxes, segms, keypoints, classes = convert_from_cls_format(
             boxes, segms, keypoints)

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -113,7 +113,6 @@ def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
 
 def vis_class(img, pos, class_str, font_scale=0.35):
     """Visualizes the class."""
-    
     img = img.astype(np.uint8)
     x0, y0 = int(pos[0]), int(pos[1])
     # Compute text size.
@@ -131,8 +130,7 @@ def vis_class(img, pos, class_str, font_scale=0.35):
 
 
 def vis_bbox(img, bbox, thick=1):
-    """Visualizes a bounding box."""
-    
+    """Visualizes a bounding box.""" 
     img = img.astype(np.uint8)
     (x0, y0, w, h) = bbox
     x1, y1 = int(x0 + w), int(y0 + h)

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -96,6 +96,7 @@ def get_class_string(class_index, score, dataset):
 
 def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     """Visualizes a single binary mask."""
+    
     img = img.astype(np.float32)
     idx = np.nonzero(mask)
 
@@ -129,7 +130,7 @@ def vis_class(img, pos, class_str, font_scale=0.35):
 
 
 def vis_bbox(img, bbox, thick=1):
-    """Visualizes a bounding box.""" 
+    """Visualizes a bounding box."""
     img = img.astype(np.uint8)
     (x0, y0, w, h) = bbox
     x1, y1 = int(x0 + w), int(y0 + h)
@@ -203,6 +204,7 @@ def vis_one_image_opencv(
         im, boxes, segms=None, keypoints=None, thresh=0.9, kp_thresh=2,
         show_box=False, dataset=None, show_class=False):
     """Constructs a numpy array with the detections visualized."""
+    
     if isinstance(boxes, list):
         boxes, segms, keypoints, classes = convert_from_cls_format(
             boxes, segms, keypoints)

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -96,6 +96,7 @@ def get_class_string(class_index, score, dataset):
 
 def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     """Visualizes a single binary mask."""
+    
     img = img.astype(np.float32)
     idx = np.nonzero(mask)
 
@@ -203,6 +204,7 @@ def vis_one_image_opencv(
         im, boxes, segms=None, keypoints=None, thresh=0.9, kp_thresh=2,
         show_box=False, dataset=None, show_class=False):
     """Constructs a numpy array with the detections visualized."""
+    
     if isinstance(boxes, list):
         boxes, segms, keypoints, classes = convert_from_cls_format(
             boxes, segms, keypoints)

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -96,7 +96,6 @@ def get_class_string(class_index, score, dataset):
 
 def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     """Visualizes a single binary mask."""
-    
     img = img.astype(np.float32)
     idx = np.nonzero(mask)
 
@@ -204,7 +203,6 @@ def vis_one_image_opencv(
         im, boxes, segms=None, keypoints=None, thresh=0.9, kp_thresh=2,
         show_box=False, dataset=None, show_class=False):
     """Constructs a numpy array with the detections visualized."""
-    
     if isinstance(boxes, list):
         boxes, segms, keypoints, classes = convert_from_cls_format(
             boxes, segms, keypoints)

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -113,6 +113,8 @@ def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
 
 def vis_class(img, pos, class_str, font_scale=0.35):
     """Visualizes the class."""
+    
+    img = img.astype(np.uint8)
     x0, y0 = int(pos[0]), int(pos[1])
     # Compute text size.
     txt = class_str
@@ -130,6 +132,8 @@ def vis_class(img, pos, class_str, font_scale=0.35):
 
 def vis_bbox(img, bbox, thick=1):
     """Visualizes a bounding box."""
+    
+    img = img.astype(np.uint8)
     (x0, y0, w, h) = bbox
     x1, y1 = int(x0 + w), int(y0 + h)
     x0, y0 = int(x0), int(y0)


### PR DESCRIPTION
Fixing error: 
TypeError: Layout of the output array img is incompatible with cv::Mat (step[ndims-1] != elemsize or step[1] != elemsize*nchannels)

in vis_class(..) and vis_bbox(..) methods when calling vis_one_image_opencv(..).