### PR TITLE
Add vanilla and optimized cpu device to detectron

### DIFF
--- a/detectron/core/config.py
+++ b/detectron/core/config.py
@@ -1007,6 +1007,7 @@ _DEPRECATED_KEYS = set(
         'TRAIN.DROPOUT',
         'USE_GPU_NMS',
         'TEST.NUM_TEST_IMAGES',
+        '--device_id'
     }
 )
 

--- a/detectron/core/test_engine.py
+++ b/detectron/core/test_engine.py
@@ -105,7 +105,8 @@ def run_inference(
                     dataset_name,
                     proposal_file,
                     output_dir,
-                    multi_gpu=multi_gpu_testing
+                    multi_gpu=multi_gpu_testing,
+                    gpu_id=gpu_id
                 )
                 all_results.update(results)
 

--- a/detectron/roi_data/loader.py
+++ b/detectron/roi_data/loader.py
@@ -182,8 +182,12 @@ class RoIDataLoader(object):
         assert len(blob_names) == len(blobs)
         t = time.time()
         dev = c2_utils.CudaDevice(gpu_id)
-        queue_name = 'gpu_{}/{}'.format(gpu_id, self._blobs_queue_name)
-        blob_names = ['gpu_{}/{}'.format(gpu_id, b) for b in blob_names]
+        if gpu_id < 0:
+            queue_name = self._blobs_queue_name
+            blob_names = blob_names
+        else:
+            queue_name = 'gpu_{}/{}'.format(gpu_id, self._blobs_queue_name)
+            blob_names = ['gpu_{}/{}'.format(gpu_id, b) for b in blob_names]
         for (blob_name, blob) in zip(blob_names, blobs):
             workspace.FeedBlob(blob_name, blob, device_option=dev)
         logger.debug(
@@ -258,6 +262,14 @@ class RoIDataLoader(object):
                         capacity=self._blobs_queue_capacity
                     )
                 )
+        if self._num_gpus == 0:
+            workspace.RunOperatorOnce(
+                core.CreateOperator(
+                    'CreateBlobsQueue', [], [self._blobs_queue_name],
+                    num_blobs=len(self.get_output_names()),
+                    capacity=self._blobs_queue_capacity
+                )
+            )
         return self.create_enqueue_blobs()
 
     def close_blobs_queues(self):
@@ -269,6 +281,12 @@ class RoIDataLoader(object):
                         'CloseBlobsQueue', [self._blobs_queue_name], []
                     )
                 )
+        if self._num_gpus == 0:
+            workspace.RunOperatorOnce(
+                core.CreateOperator(
+                    'CloseBlobsQueue', [self._blobs_queue_name], []
+                )
+            )
 
     def create_enqueue_blobs(self):
         blob_names = self.get_output_names()
@@ -279,6 +297,9 @@ class RoIDataLoader(object):
             with c2_utils.NamedCudaScope(gpu_id):
                 for blob in enqueue_blob_names:
                     workspace.CreateBlob(core.ScopedName(blob))
+        if self._num_gpus == 0:
+            for blob in enqueue_blob_names:
+                workspace.CreateBlob(core.ScopedName(blob))
         return enqueue_blob_names
 
     def register_sigint_handler(self):

--- a/detectron/utils/env.py
+++ b/detectron/utils/env.py
@@ -67,6 +67,11 @@ def get_detectron_ops_lib():
             # TODO(ilijar): Switch to using a logger
             print('Found Detectron ops lib: {}'.format(ops_path))
             break
+        ops_path = os.path.join(prefix, 'lib/libcaffe2_detectron_ops.so')
+        if os.path.exists(ops_path):
+            # TODO(ilijar): Switch to using a logger
+            print('Found Detectron ops lib: {}'.format(ops_path))
+            break
     assert os.path.exists(ops_path), \
         ('Detectron ops lib not found; make sure that your Caffe2 '
          'version includes Detectron module')

--- a/tools/infer_simple.py
+++ b/tools/infer_simple.py
@@ -99,6 +99,12 @@ def parse_args():
         default='pdf',
         type=str
     )
+    parser.add_argument(
+        '--device_id',
+        dest='device_id',
+        default=0,
+        type=int
+    )
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
@@ -118,7 +124,7 @@ def main(args):
     assert not cfg.TEST.PRECOMPUTED_PROPOSALS, \
         'Models that require precomputed proposals are not supported'
 
-    model = infer_engine.initialize_model_from_cfg(args.weights)
+    model = infer_engine.initialize_model_from_cfg(args.weights, gpu_id = args.device_id)
     dummy_coco_dataset = dummy_datasets.get_coco_dataset()
 
     if os.path.isdir(args.im_or_folder):
@@ -134,7 +140,7 @@ def main(args):
         im = cv2.imread(im_name)
         timers = defaultdict(Timer)
         t = time.time()
-        with c2_utils.NamedCudaScope(0):
+        with c2_utils.NamedCudaScope(args.device_id):
             cls_boxes, cls_segms, cls_keyps = infer_engine.im_detect_all(
                 model, im, None, timers=timers
             )

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -80,6 +80,12 @@ def parse_args():
         nargs=2
     )
     parser.add_argument(
+        '--device_id',
+        dest='device_id',
+        default=0,
+        type=int
+    )
+    parser.add_argument(
         'opts',
         help='See detectron/core/config.py for all options',
         default=None,
@@ -113,5 +119,6 @@ if __name__ == '__main__':
         cfg.TEST.WEIGHTS,
         ind_range=args.range,
         multi_gpu_testing=args.multi_gpu_testing,
+        gpu_id=args.device_id,
         check_expected_results=True,
     )


### PR DESCRIPTION
I would like to use this PR to initiate the support of CPU device paths in detectron. Changes are made minimal in this PR to ask the advice from the community a good integration approach to follow. There are two major changes:
1. detectron/utils/env.py would load "lib/libcaffe2_detectron_ops.so" if "lib/libcaffe2_detectron_ops_gpu.so" is not found. A separate PR will be submitted to PyTorch/Caffe2 to generate this dynamic lib which contains only CPU ops.
2. detectron/utils/c2.py: borrows the functions GpuNameScope/CudaScope to support vanilla CPU (gpu_id==-1) and optimized CPU (gpu_id==-2) devices.

Renaming the hard-coded GpuNameScope/CudaScope to more general names might be a more elegant approach but this would require changes of many places in detectron code. Any suggestions?