### PR TITLE
Find detectron ops from pytorch nightly build

### DIFF
--- a/detectron/utils/env.py
+++ b/detectron/utils/env.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 
 import os
 import sys
+import torch
 
 # Default value of the CMake install prefix
 _CMAKE_INSTALL_PREFIX = '/usr/local'
@@ -61,7 +62,7 @@ def import_nccl_ops():
 def get_detectron_ops_lib():
     """Retrieve Detectron ops library."""
     # Candidate prefixes for detectron ops lib path
-    prefixes = [_CMAKE_INSTALL_PREFIX, sys.prefix, sys.exec_prefix] + sys.path
+    prefixes = [_CMAKE_INSTALL_PREFIX, sys.prefix, sys.exec_prefix, os.path.dirname(torch.__file__)] + sys.path
     # Candidate subdirs for detectron ops lib
     subdirs = ['lib', 'torch/lib']
     # Try to find detectron ops lib


### PR DESCRIPTION
Detectron ops are already installed with the latest `pytorch-nightly` build (from conda).
```
find $(dirname $(python -c 'import torch; print(torch.__file__)')) -name '*detectron*.so'
# /opt/conda/lib/python3.7/site-packages/torch/lib/libcaffe2_detectron_ops_gpu.so
```