### PR TITLE
Update visualization script to work with OpenCV 4

### DIFF
--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -333,7 +333,7 @@ def vis_one_image(
                 img[:, :, c] = color_mask[c]
             e = masks[:, :, i]
 
-            if ((cv2.__version__).startswith('4.0')):
+            if ((cv2.__version__).startswith('4.')):
                 contour, hier = cv2.findContours(
                     e.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
             else:

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -104,8 +104,13 @@ def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     img[idx[0], idx[1], :] += alpha * col
 
     if show_border:
-        _, contours, _ = cv2.findContours(
-            mask.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
+        if ((cv2.__version__).startswith('4.0')):
+            contours, _ = cv2.findContours(
+                mask.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
+        else:
+            _, contours, _ = cv2.findContours(
+                mask.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
+        
         cv2.drawContours(img, contours, -1, _WHITE, border_thick, cv2.LINE_AA)
 
     return img.astype(np.uint8)
@@ -328,8 +333,12 @@ def vis_one_image(
                 img[:, :, c] = color_mask[c]
             e = masks[:, :, i]
 
-            _, contour, hier = cv2.findContours(
-                e.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
+            if ((cv2.__version__).startswith('4.0')):
+                contour, hier = cv2.findContours(
+                    e.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
+            else
+                _, contour, hier = cv2.findContours(
+                    e.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
 
             for c in contour:
                 polygon = Polygon(

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -336,7 +336,7 @@ def vis_one_image(
             if ((cv2.__version__).startswith('4.0')):
                 contour, hier = cv2.findContours(
                     e.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
-            else
+            else:
                 _, contour, hier = cv2.findContours(
                     e.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
 

--- a/detectron/utils/vis.py
+++ b/detectron/utils/vis.py
@@ -104,7 +104,7 @@ def vis_mask(img, mask, col, alpha=0.4, show_border=True, border_thick=1):
     img[idx[0], idx[1], :] += alpha * col
 
     if show_border:
-        if ((cv2.__version__).startswith('4.0')):
+        if ((cv2.__version__).startswith('4.')):
             contours, _ = cv2.findContours(
                 mask.copy(), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)
         else:


### PR DESCRIPTION
- Preparing a Detectron environment with latest PyTorch version happens to have OpenCV installed with version 4.0
- This causes `tools/infer_simple.py` to fail because it calls some functions in `vis.py` which in turn depend on OpenCV
- There is change in OpenCV 4.0 such that `findContours` function returns 2 results instead of 3
- The change in this PR is to dynamically check current OpenCV version and based on that adjust how to call `findContours`