### PR TITLE
improved symlink example code

### DIFF
--- a/detectron/datasets/data/README.md
+++ b/detectron/datasets/data/README.md
@@ -29,8 +29,8 @@ If that is not the case, you may need to do something similar to:
 
 ```
 mkdir -p $DETECTRON/detectron/datasets/data/coco
-ln -s /path/to/coco_train2014 $DETECTRON/detectron/datasets/data/coco/
-ln -s /path/to/coco_val2014 $DETECTRON/detectron/datasets/data/coco/
+ln -s /path/to/coco_train2014 $DETECTRON/detectron/datasets/data/coco/coco_train2014
+ln -s /path/to/coco_val2014 $DETECTRON/detectron/datasets/data/coco/coco_val2014
 ln -s /path/to/json/annotations $DETECTRON/detectron/datasets/data/coco/annotations
 ```
 


### PR DESCRIPTION
The current/old example does not link to the correct subdirectories.
The old example created two links to the same parent directory instead of two links to the seperate subdirectories.
I corrected the example code, so the two links link to the two seperate subdirectories.