### PR TITLE
fix pyyaml version since newer version would cause error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13
-pyyaml>=3.12
+pyyaml==3.12
 matplotlib
 opencv-python>=3.2
 setuptools


### PR DESCRIPTION
I found that newer version of pyyaml cause error while parsing yaml files. Fix the pyyaml version can solve this problem.
Reference issue: #840 