### PR TITLE
Fix convert_pkl_to_pb import error

### DIFF
--- a/tools/convert_pkl_to_pb.py
+++ b/tools/convert_pkl_to_pb.py
@@ -41,7 +41,7 @@ import detectron.utils.c2 as c2_utils
 import detectron.utils.model_convert_utils as mutils
 import detectron.utils.vis as vis_utils
 import numpy as np
-from caffe2.caffe2.fb.predictor import predictor_exporter, predictor_py_utils
+from caffe2.python.predictor import predictor_exporter, predictor_py_utils
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, workspace
 from caffe2.python.predictor_constants import predictor_constants as predictor_constants


### PR DESCRIPTION
When running: 
`python tools/convert_pkl_to_pb.py -h`

Raise an error: 
`Traceback (most recent call last):
  File "tools/convert_pkl_to_pb.py", line 44, in <module>
    from caffe2.caffe2.fb.predictor import predictor_exporter, predictor_py_utils
ModuleNotFoundError: No module named 'caffe2.caffe2'`

Change import module to fix this.
#969 