### PR TITLE
Update requirements.txt to install opencv 4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.13
 pyyaml==3.12
 matplotlib
-opencv-python>=3.2
+opencv-python==4.2.0.32
 setuptools
 Cython
 mock


### PR DESCRIPTION
Python 2.7 is not supported anymore in opencv since 4.3.0.36, the latest support for python 2.7 is opencv-python version 4.2.0.32. 
The requirement 'opencv-python>=3.2' installs the latest version which does not support python 2 anymore, which throws an error.
This replaces it with 'opencv-python==4.2.0.32'.