### PR TITLE
Introduced Safer SMTP Alternative: Added `SMTP_SSL`

### DIFF
--- a/detectron/utils/logging.py
+++ b/detectron/utils/logging.py
@@ -65,8 +65,13 @@ class SmoothedValue:
         return self.total / self.count
 
 
-def send_email(subject, body, to):
-    s = smtplib.SMTP('localhost')
+def send_email(subject, body, to, host='', port=smtplib.SMTP_PORT, username='',
+               password='', secure=False):
+    if secure:
+        s = smtplib.SMTP_SSL(host, smtplib.SMTP_SSL_PORT)
+        s.login(username, password)
+    else:
+        s = smtplib.SMTP('localhost')
     mime = MIMEText(body)
     mime['Subject'] = subject
     mime['To'] = to


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-
> In file: [logging.py](https://github.com/facebookresearch/Detectron/blob/main/detectron/utils/logging.py#L69), method: send_email, a clear-text protocol such as FTP, Telnet or SMTP is used. These protocols transfer data without any encryption, which expose applications to a large range of risks. iCR suggested that data should be transferred over only secure transport channels.


## Changes
-  Added `SMTP_SSL` option with authentication to send_email method


## Previously Found & Fixed
- https://www.github.com/google/timesketch/pull/2940
- https://www.github.com/nasa-gibs/onearth/pull/177
- https://www.github.com/geopython/pycsw/pull/917


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
